### PR TITLE
Fix racing condition for quick save after make change.

### DIFF
--- a/autosave/plugin.js
+++ b/autosave/plugin.js
@@ -223,6 +223,10 @@
     }
 
     function RemoveStorage(autoSaveKey) {
+        if (timeOutId) {
+            clearTimeout(timeOutId);
+        }
+
         localStorage.removeItem(autoSaveKey);
     }
 


### PR DESCRIPTION
If we do not clear the save to localStorage timeout, if user type something and quickly clicked the save button, next time he visit he will see a recover dialogue. Which is very annoying.
