### PR TITLE
Change the save trigger from key type to "change" event from CKEditor. 

### DIFF
--- a/autosave/plugin.js
+++ b/autosave/plugin.js
@@ -47,7 +47,7 @@
             RemoveStorage(autoSaveKey);
         });
 
-        editorInstance.on('key', startTimer);
+        editorInstance.on('change', startTimer);
 
         editorInstance.on('destroy', function() {
             if (saveOnDestroy) {


### PR DESCRIPTION
Change the save trigger from key type to "change" event from CKEditor. This will prevent user lost changes such as copy/pasty, insert image...
