### PR TITLE
Better local storage detection

### DIFF
--- a/autosave/plugin.js
+++ b/autosave/plugin.js
@@ -5,6 +5,7 @@
 
 (function() {
     if (!supportsLocalStorage()) {
+        CKEDITOR.plugins.add("autosave", {}); //register a dummy plugin to pass CKEditor plugin initialization process
         return;
     }
 
@@ -96,7 +97,16 @@
 
     // localStorage detection
     function supportsLocalStorage() {
-        return typeof (Storage) !== 'undefined';
+        if (typeof (Storage) === 'undefined') {
+            return false;
+        }
+
+        try {
+            localStorage.getItem("___test_key");
+            return true;
+        } catch (e) {
+            return false;
+        }
     }
 
     function GenerateAutoSaveDialog(editorInstance, autoSaveKey) {


### PR DESCRIPTION
On IE 11 "Storage" is defined but by default localStorage is not accessible. This will cause "Access Denied" exception and break whole CKEditor initialization in IE 11.
