### PR TITLE
wrap loadPlugin() in instanceReady event

### DIFF
--- a/autosave/plugin.js
+++ b/autosave/plugin.js
@@ -26,18 +26,20 @@
                 }
             }, editor, null, 100);
 
-            if (typeof (jQuery) === 'undefined') {
-                CKEDITOR.scriptLoader.load('//ajax.googleapis.com/ajax/libs/jquery/1/jquery.min.js', function() {
-                    jQuery.noConflict();
+            editor.on('instanceReady', function(){
+                if (typeof (jQuery) === 'undefined') {
+                    CKEDITOR.scriptLoader.load('//ajax.googleapis.com/ajax/libs/jquery/1/jquery.min.js', function() {
+                        jQuery.noConflict();
 
-                    loadPlugin(editor);
-                });
+                        loadPlugin(editor);
+                    });
 
-            } else {
-                CKEDITOR.scriptLoader.load(CKEDITOR.getUrl(CKEDITOR.plugins.getPath('autosave') + 'js/extensions.min.js'), function() {
-                    loadPlugin(editor);
-                });
-            }
+                } else {
+                    CKEDITOR.scriptLoader.load(CKEDITOR.getUrl(CKEDITOR.plugins.getPath('autosave') + 'js/extensions.min.js'), function() {
+                        loadPlugin(editor);
+                    });
+                }
+            }, editor, null, 100);
         }
     });
 


### PR DESCRIPTION
I think `loadPlugin()` should be wrapped in `instanceReady` event.

Let's consider this situation.

Assumming ...
- our application has many page using  CKEditor.
- each pages have multiple instance of CKEditor.
- we want to add autosave plugin to **ALL** CKEditor instance without making change to all affected files.
- `config.autosave_SaveKey` should be something like this ... `autosave_[url]_[instanceName]`

In this case, we can use `instanceReady` event to modify `autoSaveKey` value to be unique in each instances.

``` javascript
CKEDITOR.on('instanceReady', function(e) {
    e.editor.config.autosave_SaveKey = 'autosave_' + window.location + '_' + e.editor.name;
});
```

But problem is, we cannot use `instanceReady` to do the job since `loadPlugin()` is immediately called  in plugin's `init` callback, which make it execute before the `instanceReady` event.

With my pull request and this work around we can dynamically create a unique key for each instances without making change to all affected files. (Just place above code right after ckeditor.js <script> tag)

Thanks for the great plugin,
Porawit Poboonma
