### PR TITLE
Exchanged getData() with getSnapshot().

### DIFF
--- a/autosave/plugin.js
+++ b/autosave/plugin.js
@@ -190,7 +190,7 @@
             var autoSavedContent = jsonSavedContent.data;
             var autoSavedContentDate = jsonSavedContent.saveTime;
 
-            var editorLoadedContent = editorInstance.getData();
+            var editorLoadedContent = editorInstance.getSnapshot();
 
             // check if the loaded editor content is the same as the autosaved content
             if (editorLoadedContent == autoSavedContent) {
@@ -221,7 +221,7 @@
     }
 
     function SaveData(autoSaveKey, editorInstance) {
-        var compressedJSON = LZString.compressToUTF16(JSON.stringify({ data: editorInstance.getData(), saveTime: new Date() }));
+        var compressedJSON = LZString.compressToUTF16(JSON.stringify({ data: editorInstance.getSnapshot(), saveTime: new Date() }));
         localStorage.setItem(autoSaveKey, compressedJSON);
 
         var autoSaveMessage = document.getElementById(autoSaveMessageId(editorInstance));
@@ -246,7 +246,7 @@
     function RenderDiff(dialog, editorInstance, autoSaveKey) {
         var jsonSavedContent = LoadData(autoSaveKey);
 
-        var base = difflib.stringAsLines(editorInstance.getData());
+        var base = difflib.stringAsLines(editorInstance.getSnapshot());
         var newtxt = difflib.stringAsLines(jsonSavedContent.data);
         var sm = new difflib.SequenceMatcher(base, newtxt);
         var opcodes = sm.get_opcodes();


### PR DESCRIPTION
I exchanged getData() with getSnapshot(). Reason:

getData() is the editor content AFTER transformation that might occur "onToDataFormat". getSnapshot() is the raw data without transformations.

http://docs.ckeditor.com/#!/api/CKEDITOR.editor-method-getData
This part of the documentation reads 'The data will be in "raw" format.' That's wrong. The data is processed with e.editor.on( 'toDataFormat', function(event) {...}).

http://docs.ckeditor.com/#!/api/CKEDITOR.editor-method-getSnapshot
From the documentation: 'Gets the "raw data" currently available in the editor. This is a fast method which returns the data as is, without processing, so it is not recommended to use it on resulting pages. Instead it can be used combined with the loadSnapshot method in order to automatically save the editor data from time to time while the user is using the editor, to avoid data loss, without risking performance issues.'
