### PR TITLE
Added "no:" label for swedish

### DIFF
--- a/autosave/lang/sv.js
+++ b/autosave/lang/sv.js
@@ -11,6 +11,7 @@ CKEDITOR.plugins.setLang('autosave', 'sv', {
     loadedContent: 'Inladdat innehåll',
     autoSavedContent: 'Autosparat innehåll (från: \'',
 	ok: 'Läs in Autosparat innehåll',
+	no: 'Nej tack',
 	diffType: 'Visa skillnader:',
 	sideBySide: 'Sida vid sida',
 	inline: 'Ihop'


### PR DESCRIPTION
When you are presented with the diff view in swedish you get a
"undefined" button instead of No thanks.