### PR TITLE
Issue #99 rename package to lowercase for NPM

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "CKEditor-AutoSave-Plugin",
+  "name": "ckeditor-autoSave-plugin",
   "version": "0.18.2",
   "author": "w8tcha",
   "description": "Auto Save Plugin for the CKEditor which automatically saves the content (via HTML5 LocalStorage) ",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "ckeditor-autoSave-plugin",
+  "name": "ckeditor-autosave-plugin",
   "version": "0.18.2",
   "author": "w8tcha",
   "description": "Auto Save Plugin for the CKEditor which automatically saves the content (via HTML5 LocalStorage) ",


### PR DESCRIPTION
It turns out that new packages cannot be added to NPMjs.com with uppercase letters in the package name. This sets them to lowercase.