### PR TITLE
fix: loadPlugin is fired before extensions.min.js is loaded when usin…

### DIFF
--- a/autosave/plugin.js
+++ b/autosave/plugin.js
@@ -62,8 +62,9 @@
 
             editor.on('instanceReady', function () {
                 if (typeof requirejs === "function") {
-                    requirejs([CKEDITOR.getUrl(CKEDITOR.plugins.getPath('autosave') + 'js/extensions.min.js')]);
-                    loadPlugin(editor, config);
+                    requirejs([CKEDITOR.getUrl(CKEDITOR.plugins.getPath('autosave') + 'js/extensions.min.js')], function() {
+                        loadPlugin(editor, config);
+                    });
                 } else {
                     CKEDITOR.scriptLoader.load(CKEDITOR.getUrl(CKEDITOR.plugins.getPath('autosave') + 'js/extensions.min.js'), function () {
                         loadPlugin(editor, config);


### PR DESCRIPTION
Ran into an issue where when using require js, where the `loadPlugin(editor, config)` is called before the `js/entensions.min.js` is loaded.  

Fixed it by wrapping the call to `loadPlugin(...)` in the `requirejs` callback.

I also ran into an issue where when using requirejs that moment.js isn't loaded correctly on the global `window` object.   But I don't have the bandwidth to troubleshoot that at the moment...